### PR TITLE
fix: incorrect parentheses

### DIFF
--- a/.changeset/quick-shirts-grin.md
+++ b/.changeset/quick-shirts-grin.md
@@ -1,0 +1,5 @@
+---
+"ts-macro-relay": patch
+---
+
+fix: incorrect parentheses

--- a/packages/ts-macro-relay/src/index.ts
+++ b/packages/ts-macro-relay/src/index.ts
@@ -111,7 +111,7 @@ export const relayPlugin = createPlugin<RelayPluginOptions>(
 								codes,
 								node.pos,
 								node.end,
-								`(${node.getText(ast)} as (import("relay-runtime").GraphQLTaggedNode & { [" $graphql"]: import("./__generated__/${decl.name}.graphql").${decl.name}) }))`,
+								`(${node.getText(ast)} as (import("relay-runtime").GraphQLTaggedNode & { [" $graphql"]: import("./__generated__/${decl.name}.graphql").${decl.name} }))`,
 							);
 						}
 					} finally {


### PR DESCRIPTION
After applying ts-macro-relay, a type syntax error occurred. Upon checking, I noticed that an unnecessary closing parenthesis had been added.