### PR TITLE
fix: handle method chaining to prevent duplicate AST processing

### DIFF
--- a/.changeset/quick-shirts-grin.md
+++ b/.changeset/quick-shirts-grin.md
@@ -1,0 +1,7 @@
+---
+"ts-macro-relay": patch
+---
+
+fix: handle method chaining to prevent duplicate AST processing
+
+Fixes TypeError when using method chaining with Relay functions like `fetchQuery(...).toPromise()`. The plugin now detects and skips outer method calls to avoid processing the same node twice with incorrect arguments.


### PR DESCRIPTION
## Summary
- Fixes TypeError when using method chaining with Relay functions (e.g., `fetchQuery(...).toPromise()`)
- Adds detection for method chain patterns to skip duplicate AST node processing
- Prevents "Cannot use 'in' operator to search for 'length' in undefined" error

## Problem
When using method chaining with Relay functions, the plugin was processing both the outer method call (`.toPromise()`) and the inner Relay function call (`fetchQuery`), causing it to attempt processing the outer call with incorrect/empty arguments.

## Solution
Added method chain detection logic that:
1. Identifies when a node is an outer call in a method chain pattern
2. Checks if the inner call is a target Relay function
3. Skips processing the outer call to avoid duplicate handling

## Test Plan
- [ ] Verify that `fetchQuery(...).toPromise()` works without throwing TypeError
- [ ] Ensure regular Relay function calls still work correctly
- [ ] Test other method chaining patterns with Relay functions
- [ ] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)